### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 
 <h1>Piscine_42_fevrier_2020</h1>
 
+[![Run on Repl.it](https://repl.it/badge/github/theJzonn/piscine)](https://repl.it/github/theJzonn/piscine)
+
 ```diff
 + C_00: 85%
 + ex00:OK | ex01:OK | ex02:OK | ex03:OK | ex04:OK | ex05:OK | ex06:OK | ex07:OK


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).